### PR TITLE
libvncclient: add error logging when SSL_CTX_new() fails

### DIFF
--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -263,7 +263,16 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
 
   if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
   {
+    unsigned long err_no;
+
     rfbClientLog("Could not create new SSL context.\n");
+    while((err_no = ERR_get_error()) != 0)
+    {
+      char err_buf[256];
+
+      ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
+      rfbClientLog("\t error: %s(%d)\n", err_buf, err_no);
+    }
     return NULL;
   }
 

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -265,13 +265,13 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
   {
     unsigned long err_no;
 
-    rfbClientLog("Could not create new SSL context.\n");
+    fprintf(stderr, "Could not create new SSL context.\n");
     while((err_no = ERR_get_error()) != 0)
     {
       char err_buf[256];
 
       ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
-      rfbClientLog("\t error: %s(%d)\n", err_buf, err_no);
+      fprintf(stderr, "\t error: %s(%d)\n", err_buf, err_no);
     }
     return NULL;
   }

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -271,7 +271,7 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
       char err_buf[256];
 
       ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
-      fprintf(stderr, "\t error: %s(%d)\n", err_buf, err_no);
+      fprintf(stderr, " -  %s\n", err_buf);
     }
     return NULL;
   }


### PR DESCRIPTION
`SSL_CTX_new()` 함수 실패할 때 로그를 기록합니다. (원격 화면 접속 안 됨 nvrsw/emx#547)