### PR TITLE
Revert "libvncclient: add error logging when SSL_CTX_new() fails" 

### DIFF
--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -263,16 +263,7 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
 
   if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
   {
-    unsigned long err_no;
-
-    fprintf(stderr, "Could not create new SSL context.\n");
-    while((err_no = ERR_get_error()) != 0)
-    {
-      char err_buf[256];
-
-      ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
-      fprintf(stderr, " -  %s\n", err_buf);
-    }
+    rfbClientLog("Could not create new SSL context.\n");
     return NULL;
   }
 

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -150,7 +150,6 @@ InitializeTLS(void)
   if (!InitLockingCb())
     return FALSE;
 
-  SSL_library_init();
   SSL_load_error_strings();
   SSLeay_add_ssl_algorithms();
   RAND_load_file("/dev/urandom", 1024);

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -150,6 +150,7 @@ InitializeTLS(void)
   if (!InitLockingCb())
     return FALSE;
 
+  SSL_library_init();
   SSL_load_error_strings();
   SSLeay_add_ssl_algorithms();
   RAND_load_file("/dev/urandom", 1024);


### PR DESCRIPTION
`SSL_CTX_new()` 함수 실패 디버깅 로그 출력 커밋을 revert하며, ~~`InitializeTLS ()` 함수에서 SSL 라이브러리 초기화 함수를 추가합니다.~~  (원격 화면 접속 안 됨 nvrsw/emx#547)