### PR TITLE
libvncclient: add error logging when SSL_CTX_new() failure

### DIFF
--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -266,13 +266,12 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
     unsigned long err_no;
 
     rfbClientLog("Could not create new SSL context.\n");
-    fprintf(stderr, "reason:\n");
     while((err_no = ERR_get_error()) != 0)
     {
       char err_buf[256];
 
       ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
-      fprintf(stderr, " -  %s\n", err_buf);
+      fprintf(stderr, "reason: %s\n", err_buf);
     }
     return NULL;
   }

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -263,7 +263,17 @@ open_ssl_connection (rfbClient *client, int sockfd, rfbBool anonTLS, rfbCredenti
 
   if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method())))
   {
+    unsigned long err_no;
+
     rfbClientLog("Could not create new SSL context.\n");
+    fprintf(stderr, "reason:\n");
+    while((err_no = ERR_get_error()) != 0)
+    {
+      char err_buf[256];
+
+      ERR_error_string_n(err_no, err_buf, sizeof(err_buf));
+      fprintf(stderr, " -  %s\n", err_buf);
+    }
     return NULL;
   }
 


### PR DESCRIPTION
SSL_CTX_new() 함수가 실패할 때 이유를 로그에 남기도록 합니다. (원격 화면 접속 안 됨 #547)